### PR TITLE
Api for uploading a certifications file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'factory_bot', '~> 6.1.0'
+  gem 'factory_bot_rails', '~> 6.1.0'
   gem 'faker', '~> 2.15.1'
   gem 'rspec-rails', '~> 4.0.1'
 end
@@ -37,6 +37,10 @@ group :development do
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+end
+
+group :test do
+  gem 'active_storage_validations'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.9.0)
+      rails (>= 5.2.0)
     activejob (6.1.0)
       activesupport (= 6.1.0)
       globalid (>= 0.3.6)
@@ -70,6 +72,9 @@ GEM
     erubi (1.10.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     faker (2.15.1)
       i18n (>= 1.6, < 2)
     ffi (1.13.1)
@@ -169,9 +174,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap (>= 1.4.4)
   byebug
-  factory_bot (~> 6.1.0)
+  factory_bot_rails (~> 6.1.0)
   faker (~> 2.15.1)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Bikes Anonymous
 
 Example Rails API for a company providing certifications for cyclists.
+
+## Requirements
+Ruby `2.7.1`
+Rails `6.1.0`
+Postgres
+## Installation
+`bin/setup`
+
+### User Story 1 - Upload of certifications file
+Firstly, setup and start the app ( by running the command `bin/setup`).
+
+Then, in the app directory, run following requests
+
+- Correct, authorized request:
+`curl -H 'Authorization-Token: present' -F source_file=@./spec/fixtures/files/example_certifications_source.csv http://localhost:3000/api/certificates_sources`
+
+- Unauthorized request:
+`curl -F import_file=@./spec/fixtures/files/example_certifications_source.csv http://localhost:3000/api/certificates_sources`

--- a/app/controllers/api/api_base_controller.rb
+++ b/app/controllers/api/api_base_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  class ApiBaseController < ApplicationController
+    before_action :authorize!
+
+    private
+
+    def authorize!
+      render json: { message: 'You are not authorized!' }, status: :unauthorized unless request.headers['HTTP_AUTHORIZATION_TOKEN'].present?
+    end
+  end
+end

--- a/app/controllers/api/certificates_sources_controller.rb
+++ b/app/controllers/api/certificates_sources_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  class CertificatesSourcesController < ::Api::ApiBaseController
+    def create
+      certificates_source = CertificatesSource.create(source_file: params[:source_file])
+
+      if certificates_source.persisted? && ProcessCertificatesSourceJob.perform_later(certificates_source.id)
+        render json: { id: certificates_source.id, message: 'Source file scheduled for processing.' }, status: :created
+      else
+        render json: { errors: certificates_source.errors.messages }, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/jobs/process_certificates_source_job.rb
+++ b/app/jobs/process_certificates_source_job.rb
@@ -1,0 +1,7 @@
+class ProcessCertificatesSourceJob < ApplicationJob
+  queue_as :certificates_sources
+
+  def perform(source_id)
+    ::CertificatesSources::SourceProcessor.call(CertificatesSource.find(source_id))
+  end
+end

--- a/app/models/certificates_source.rb
+++ b/app/models/certificates_source.rb
@@ -1,0 +1,5 @@
+class CertificatesSource < ApplicationRecord
+  has_one_attached :source_file
+
+  validates :source_file, attached: true, content_type: :csv
+end

--- a/app/services/certificates_sources/source_processor.rb
+++ b/app/services/certificates_sources/source_processor.rb
@@ -1,0 +1,12 @@
+module CertificatesSources
+  class SourceProcessor < ServiceBase
+    def initalize(certifications_source)
+      @certifications_source = certifications_source
+    end
+
+    def call
+      # Read source file
+      # For every certificate entry, trigger HandleCertificateJob
+    end
+  end
+end

--- a/app/services/service_base.rb
+++ b/app/services/service_base.rb
@@ -1,0 +1,7 @@
+class ServiceBase
+  def initialize(*args); end
+
+  def self.call(*args, **params)
+    new(*args, **params).call
+  end
+end

--- a/app/validators/attached_validator.rb
+++ b/app/validators/attached_validator.rb
@@ -1,0 +1,9 @@
+# QUICK FIX - https://github.com/igorkasyanchuk/active_storage_validations/blob/master/lib/active_storage_validations/attached_validator.rb
+
+class AttachedValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    return if record.send(attribute).attached?
+
+    record.errors.add(attribute, :blank)
+  end
+end

--- a/app/validators/content_type_validator.rb
+++ b/app/validators/content_type_validator.rb
@@ -1,0 +1,44 @@
+# QUICK FIX - https://github.com/igorkasyanchuk/active_storage_validations/blob/master/lib/active_storage_validations/content_type_validator.rb
+
+class ContentTypeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    return true if !record.send(attribute).attached? || types.empty?
+
+    files = Array.wrap(record.send(attribute))
+
+    errors_options = { authorized_types: types_to_human_format }
+    errors_options[:message] = options[:message] if options[:message].present?
+
+    files.each do |file|
+      next if is_valid?(file)
+
+      errors_options[:content_type] = content_type(file)
+      record.errors.add(attribute, :content_type_invalid, errors_options)
+      break
+    end
+  end
+
+  def types
+    (Array.wrap(options[:with]) + Array.wrap(options[:in])).compact.map do |type|
+      Mime[type] || type
+    end
+  end
+
+  def types_to_human_format
+    types
+      .map { |type| type.to_s.split('/').last.upcase }
+      .join(', ')
+  end
+
+  def content_type(file)
+    file.blob.present? && file.blob.content_type
+  end
+
+  def is_valid?(file)
+    if options[:with].is_a?(Regexp)
+      options[:with].match?(content_type(file).to_s)
+    else
+      content_type(file).in?(types)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    resources :certificates_sources, only: [:create]
+  end
 end

--- a/db/migrate/20201214160640_create_certificates_sources.rb
+++ b/db/migrate/20201214160640_create_certificates_sources.rb
@@ -1,0 +1,8 @@
+class CreateCertificatesSources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :certificates_sources do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201214172828_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20201214172828_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,44 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_12_14_172828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "certificates_sources", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/spec/factories/certificates_source_factory.rb
+++ b/spec/factories/certificates_source_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :certificates_source do
+    source_file { ::Rack::Test::UploadedFile.new('spec/fixtures/files/example_certifications_source.csv', 'text/csv') }
+  end
+end

--- a/spec/fixtures/files/example_certifications_source.csv
+++ b/spec/fixtures/files/example_certifications_source.csv
@@ -1,0 +1,2 @@
+firstname,surname,email_address,street_address_1,street_address_2,city,state,postcode,phone
+John,Doe,john@doe.com,Calle 34,,Barcelona,TU54B,0807594850

--- a/spec/jobs/process_certificates_source_job_spec.rb
+++ b/spec/jobs/process_certificates_source_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe ProcessCertificatesSourceJob, type: :job do
+  let(:certificates_source) { create(:certificates_source) }
+
+  describe '#perform_now' do
+    it 'finds source and calls source processor' do
+      expect(::CertificatesSources::SourceProcessor).to receive(:call).with(certificates_source)
+
+      ProcessCertificatesSourceJob.perform_now(certificates_source.id)
+    end
+  end
+end

--- a/spec/models/certificates_source_spec.rb
+++ b/spec/models/certificates_source_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CertificatesSource, type: :model do
+  it { is_expected.to validate_content_type_of(:source_file).allowing('text/csv') }
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/api/api_authorization_spec.rb
+++ b/spec/requests/api/api_authorization_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'API Authorization', type: :request do
+  describe 'authorization header' do
+    context 'when correct header is present' do
+      let(:params) { { source_file: Rack::Test::UploadedFile.new(file_fixture('example_certifications_source.csv').to_path, 'text/csv') } }
+
+      it 'correctly processes request' do
+        post '/api/certificates_sources', headers: { 'Authorization-Token': 'true' }, params: params
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'when correct header is missing' do
+      it 'returns 401 unauthorized status' do
+        post '/api/certificates_sources'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/api/certificates_sources_request_spec.rb
+++ b/spec/requests/api/certificates_sources_request_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::CertificatesSources', type: :request do
+  let(:headers) { { 'Authorization-Token': 'true' } }
+
+  describe 'POST' do
+    context 'when correct source file is provided' do
+      let(:params) { { source_file: Rack::Test::UploadedFile.new(file_fixture('example_certifications_source.csv').to_path, 'text/csv') } }
+
+      it 'creates new CertificatesSource object with the uploaded file' do
+        expect { post '/api/certificates_sources', headers: headers, params: params }.to change { CertificatesSource.count }.by(1)
+        expect(CertificatesSource.last.source_file.present?).to be_truthy
+      end
+
+      it 'schedules ProcessCertificatesSourceJob' do
+        expect { post '/api/certificates_sources', headers: headers, params: params }.to have_enqueued_job(ProcessCertificatesSourceJob)
+      end
+
+      describe 'response' do
+        before { post '/api/certificates_sources', headers: headers, params: params }
+
+        it 'returns a 201 Created status' do
+          expect(response).to have_http_status(:created)
+        end
+
+        it 'returns json content type' do
+          expect(response.content_type).to eq('application/json; charset=utf-8')
+        end
+
+        it 'returns json with created certificates source id' do
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response['id']).to eq(CertificatesSource.last.id)
+        end
+      end
+    end
+
+    context 'when source file is not valid' do
+      let(:params) { { source_file: Rack::Test::UploadedFile.new(Tempfile.new('incorrect_file').path, 'text/plain') } }
+
+      before { post '/api/certificates_sources', headers: headers, params: params }
+
+      it 'returns 400 Bad Request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns json content type' do
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+      end
+
+      it 'returns json with error messages' do
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response['errors']['source_file']).to include('has an invalid content type')
+      end
+    end
+  end
+end

--- a/spec/services/certificates_sources/source_processor_spec.rb
+++ b/spec/services/certificates_sources/source_processor_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe ::CertificatesSources::SourceProcessor do
+  describe '.call' do
+    it 'schedules HandleCertificateJob for every entry in the source file' do
+      skip '[TO DO] Not yet implemented...'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  require 'active_storage_validations/matchers'
+
+  config.include ActiveStorageValidations::Matchers
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
Breaking changes:
- certificates_source table created
- active storage tables created
- gems active_storage_validations and factory_bot_rails added
- gem factory_bot removed

Changes:
- Triggering processing by uploading csv through api added
- Endpoint POST /api/certificates_sources exposed
- Controller for receiving and handling the incoming request added
- Mocked Active Jobs for processing file added
- Base API Controller for authorizing api calls added
- CertificationSource model created
- Specs for the functionalities mentioned above defined

Resolves #2