### PR TITLE
Certificate mailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,9 @@ group :development do
 end
 
 group :test do
-  gem 'active_storage_validations'
+  gem 'active_storage_validations', '~> 0.9.0'
 end
 
+gem 'prawn', '~> 2.3.0'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,11 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pdf-core (0.8.1)
     pg (1.2.3)
+    prawn (2.3.0)
+      pdf-core (~> 0.8.1)
+      ttfunk (~> 1.6)
     puma (5.1.1)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -163,6 +167,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (1.0.1)
+    ttfunk (1.6.2.1)
     tzinfo (2.0.3)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.3)
@@ -174,13 +179,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_storage_validations
+  active_storage_validations (~> 0.9.0)
   bootsnap (>= 1.4.4)
   byebug
   factory_bot_rails (~> 6.1.0)
   faker (~> 2.15.1)
   listen (~> 3.3)
   pg (~> 1.1)
+  prawn (~> 2.3.0)
   puma (~> 5.0)
   rails (~> 6.1.0)
   rspec-rails (~> 4.0.1)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ Postgres
 `bin/setup`
 
 ### User Story 1 - Upload of certifications file
-Firstly, setup and start the app ( by running the command `bin/setup`).
-
-Then, in the app directory, run following requests
+1. Firstly, setup and start the app ( by running the command `bin/setup`).
+2. In the app directory, run following requests
 
 - Correct, authorized request:
 `curl -H 'Authorization-Token: present' -F source_file=@./spec/fixtures/files/example_certifications_source.csv http://localhost:3000/api/certificates_sources`
 
 - Unauthorized request:
 `curl -F import_file=@./spec/fixtures/files/example_certifications_source.csv http://localhost:3000/api/certificates_sources`
+
+### User Story 2 - Generate Certificate PDF
+
+1. Start the app.
+2. Enter `http://localhost:3000/rails/mailers/pdf_certificate_mailer` - it will show a preview of the email, with the certificate as attached pdf. The data is randomly generated after every reload.

--- a/app/mailers/pdf_certificate_mailer.rb
+++ b/app/mailers/pdf_certificate_mailer.rb
@@ -1,0 +1,6 @@
+class PdfCertificateMailer < ApplicationMailer
+  def send_certificate(recipient, certificate_pdf_file)
+    attachments['certificate.pdf'] = certificate_pdf_file.read
+    mail(to: recipient, subject: 'BA cycling certificate')
+  end
+end

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,0 +1,3 @@
+class Certificate < ApplicationRecord
+  # Validate presence of all certificate fields
+end

--- a/app/services/certificates/pdf_certificate_generator.rb
+++ b/app/services/certificates/pdf_certificate_generator.rb
@@ -1,0 +1,51 @@
+module Certificates
+  class PdfCertificateGenerator < ServiceBase
+    ATTRIBUTES_TO_INCLUDE = %i[first_name surname email address_line_1 address_line_2 city state postcode phone].freeze
+
+    def initialize(**attributes)
+      @attributes = attributes.with_indifferent_access.slice(*ATTRIBUTES_TO_INCLUDE)
+      @pdf = Prawn::Document.new
+      super()
+    end
+
+    def call
+      save_to_tempfile do
+        render_pdf_file
+      end
+    end
+
+    private
+
+    def save_to_tempfile(&block)
+      file = Tempfile.new(['certificate_pdf', '.pdf'], nil, binmode: true)
+      file.write block.call
+      file.rewind
+      file
+    end
+
+    def render_pdf_file
+      @pdf.define_grid(columns: 2, rows: @attributes.size + 1, gutter: 10)
+
+      add_certificate_header
+      add_certificate_attributes
+
+      @pdf.render
+    end
+
+    def add_certificate_header
+      @pdf.grid(0, 0).bounding_box do
+        @pdf.text 'BA Certificate', style: :bold
+      end
+    end
+
+    def add_certificate_attributes
+      @attributes.each_with_index do |attribute, index|
+        attribute.each_with_index do |attribute_part, part_index|
+          @pdf.grid(index + 1, part_index).bounding_box do
+            @pdf.text attribute_part.humanize
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/pdf_certificate_mailer/send_certificate.html
+++ b/app/views/pdf_certificate_mailer/send_certificate.html
@@ -1,0 +1,3 @@
+<h1>Your Certificate is now ready!</h1>
+
+<p>You can now enjoy thousands of beautiful moments on your bike!</p>

--- a/db/migrate/20201214194250_create_certificates.rb
+++ b/db/migrate/20201214194250_create_certificates.rb
@@ -1,0 +1,17 @@
+class CreateCertificates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :certificates do |t|
+      t.string :first_name
+      t.string :surname
+      t.string :email
+      t.string :address_line_1
+      t.string :address_line_2
+      t.string :city
+      t.string :state
+      t.string :postcode
+      t.string :phone
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_172828) do
+ActiveRecord::Schema.define(version: 2020_12_14_194250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,20 @@ ActiveRecord::Schema.define(version: 2020_12_14_172828) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "certificates", force: :cascade do |t|
+    t.string "first_name"
+    t.string "surname"
+    t.string "email"
+    t.string "address_line_1"
+    t.string "address_line_2"
+    t.string "city"
+    t.string "state"
+    t.string "postcode"
+    t.string "phone"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "certificates_sources", force: :cascade do |t|

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :certificate do
+    first_name { Faker::Name.first_name }
+    surname { Faker::Name.last_name }
+    email { Faker::Internet.email }
+    address_line_1 { Faker::Address.street_name }
+    address_line_2 { Faker::Address.secondary_address }
+    city { Faker::Address.city }
+    state { Faker::Address.state }
+    postcode { Faker::Address.postcode }
+    phone { Faker::PhoneNumber.phone_number }
+  end
+end

--- a/spec/mailers/pdf_certificate_mailer_spec.rb
+++ b/spec/mailers/pdf_certificate_mailer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe PdfCertificateMailer, type: :mailer do
+  describe 'send_certificate' do
+    let(:certificate) { build(:certificate) }
+    let(:generated_certificate_pdf) { ::Certificates::PdfCertificateGenerator.call(**certificate.attributes) }
+
+    let(:mail) { PdfCertificateMailer.send_certificate(certificate.email, generated_certificate_pdf) }
+
+    it 'sets the headers' do
+      expect(mail.subject).to eq('BA cycling certificate')
+      expect(mail.to).to eq([certificate.email])
+    end
+
+    it 'has the certificate file attached' do
+      expect(mail.attachments.size).to eq(1)
+      expect(mail.attachments.first.filename).to eq('certificate.pdf')
+    end
+  end
+end

--- a/spec/mailers/previews/pdf_certificate_mailer_preview.rb
+++ b/spec/mailers/previews/pdf_certificate_mailer_preview.rb
@@ -1,0 +1,10 @@
+require 'factory_bot'
+# Preview all emails at http://localhost:3000/rails/mailers/pdf_certificate_mailer
+class PdfCertificateMailerPreview < ActionMailer::Preview
+  def send_certificate
+    certificate_attributes = FactoryBot.build(:certificate).attributes
+    generated_pdf_file = ::Certificates::PdfCertificateGenerator.call(**certificate_attributes)
+
+    PdfCertificateMailer.send_certificate(certificate_attributes['email'], generated_pdf_file)
+  end
+end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Certificate, type: :model do
+  # Test validations of all fields
+end

--- a/spec/services/certificates/pdf_certificate_generator_spec.rb
+++ b/spec/services/certificates/pdf_certificate_generator_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe ::Certificates::PdfCertificateGenerator do
+  describe '.call' do
+    let(:certificate_attributes) { attributes_for(:certificate)}
+
+    subject { ::Certificates::PdfCertificateGenerator.call(**certificate_attributes) }
+
+    it 'returns pdf file' do
+      expect(subject.path).to match(/\.pdf/)
+    end
+  end
+end


### PR DESCRIPTION
Breaking changes:
- `certificates` table created
- `prawn` gem added (for PDF generation)

Changes:
- `PdfCertificateMailer` for sending emails with an attached certificate added
- `PdfCertificateGenerator` for creating the certificate file added
- Specs which cover mailer and pdf generator added

Resolves #3