### PR TITLE
Daily summary mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,10 @@ Postgres
 ### User Story 2 - Generate Certificate PDF
 
 1. Start the app.
-2. Enter `http://localhost:3000/rails/mailers/pdf_certificate_mailer` - it will show a preview of the email, with the certificate as attached pdf. The data is randomly generated after every reload.
+2. Enter `http://localhost:3000/rails/mailers/pdf_certificate_mailer/send_certificate` - it will show a preview of the email, with the certificate as an attached pdf. The data is randomly generated after every reload.
+
+### User Story 3 - Daily activity summary
+
+1. Start the app
+2. Enter `http://localhost:3000/rails/mailers/daily_activity_mailer/send_summary` - it will show a preview of the daily summary email with mocked data.
+3. Run `cat config/example_sidekiq_schedule.yml` - it will show the defined cron, which would trigger daily summary email at 7 am.

--- a/app/jobs/send_daily_summary_job.rb
+++ b/app/jobs/send_daily_summary_job.rb
@@ -1,0 +1,11 @@
+class SendDailySummaryJob < ApplicationJob
+  queue_as :daily_summary
+
+  def perform
+    summary = ::Activities::DailySummaryDataProvider.call(Time.now)
+
+    Admin.all.pluck(:email).each do |admin_email|
+      DailyActivityMailer.send_summary(admin_email, '06/01/21', **summary)
+    end
+  end
+end

--- a/app/mailers/daily_activity_mailer.rb
+++ b/app/mailers/daily_activity_mailer.rb
@@ -1,0 +1,8 @@
+class DailyActivityMailer < ApplicationMailer
+  def send_summary(recipient, target_day, **activities_summary)
+    @certificates_sources_activities = activities_summary[:certificates_sources]
+    @certificates_activities = activities_summary[:certificates]
+
+    mail(to: recipient, subject: "BA activies summary for #{target_day}")
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,2 @@
+class Admin < ApplicationRecord
+end

--- a/app/services/activities/daily_summary_data_provider.rb
+++ b/app/services/activities/daily_summary_data_provider.rb
@@ -1,0 +1,16 @@
+module Activities
+  class DailySummaryDataProvider < ServiceBase
+    def initalize(target_time)
+      @target_time = target_time
+    end
+
+    def call
+      # Find all new certificates files uploaded in the @target_time - 24hr.
+      # Sum successful generations and failed.
+      # Return results in a hash:
+      # { certificates_sources: { new: 15, succesfully_processed: 7, partially_processed: 5, failed: 3 },
+      #   certificates:         { entries: 5439, generated_and_sent: 5209, failed: 20 } }
+      #
+    end
+  end
+end

--- a/app/views/daily_activity_mailer/send_summary.html.erb
+++ b/app/views/daily_activity_mailer/send_summary.html.erb
@@ -1,0 +1,12 @@
+<h1>Daily activities summary.</h1>
+
+<p>There were <%= @certificates_sources_activities[:new] %> new certificates files uploaded.</p>
+<p><%= @certificates_sources_activities[:succesfully_processed] %> were succesfully processed.</p>
+<p><%= @certificates_sources_activities[:partially_processed] %> were partially processed.</p>
+<p><%= @certificates_sources_activities[:failed] %> failed.</p>
+
+<hr>
+
+<p>In the sources, there were <%= @certificates_activities[:entries] %> certificates.</p>
+<p><%= @certificates_activities[:generated_and_sent] %> were succesfully generated and sent.</p>
+<p>Generation of <%= @certificates_activities[:failed] %> certificates failed.</p>

--- a/config/example_sidekiq_schedule.yml
+++ b/config/example_sidekiq_schedule.yml
@@ -1,0 +1,4 @@
+:schedule:
+  daily_sumamry:
+    cron: '0 7 * * *' # Runs every day, at 7 am
+    class: SendDailySummaryJob

--- a/db/migrate/20201214212427_create_admins.rb
+++ b/db/migrate/20201214212427_create_admins.rb
@@ -1,0 +1,9 @@
+class CreateAdmins < ActiveRecord::Migration[6.1]
+  def change
+    create_table :admins do |t|
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_194250) do
+ActiveRecord::Schema.define(version: 2020_12_14_212427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,12 @@ ActiveRecord::Schema.define(version: 2020_12_14_194250) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "certificates", force: :cascade do |t|

--- a/spec/factories/admin_factory.rb
+++ b/spec/factories/admin_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :admin do
+    email { Faker::Internet.email }
+  end
+end

--- a/spec/jobs/send_daily_summary_job_spec.rb
+++ b/spec/jobs/send_daily_summary_job_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe SendDailySummaryJob, type: :job do
+  describe '#perform_now' do
+    let(:admins) { create_list(:admin, 2) }
+    let(:empty_summary) { { certificates_sources: {}, certificates: {} } }
+    let(:target_date) { Time.zone.parse('2021-06-01') }
+
+    before do
+      allow(::Activities::DailySummaryDataProvider).to receive(:call).and_return(empty_summary)
+    end
+
+    it 'calls daily summary mailer for all admins' do
+      admins.each do |admin|
+        expect(::DailyActivityMailer).to receive(:send_summary).with(admin.email, '06/01/21', **empty_summary)
+      end
+
+      SendDailySummaryJob.perform_now
+    end
+
+    it 'calls daily summary data provider to get results summary data ' do
+      allow(Time).to receive(:now).and_return(target_date)
+      expect(::Activities::DailySummaryDataProvider).to receive(:call).with(target_date).and_return(empty_summary)
+
+      SendDailySummaryJob.perform_now
+    end
+  end
+end

--- a/spec/mailers/daily_activity_mailer_spec.rb
+++ b/spec/mailers/daily_activity_mailer_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DailyActivityMailer, type: :mailer do
+  describe 'send_summary' do
+    let(:admin_email) { build(:admin).email }
+    let(:activities_summary) do
+      { certificates_sources: { new: 15, succesfully_processed: 7, partially_processed: 5, failed: 3 },
+        certificates:         { entries: 5439, generated_and_sent: 5209, failed: 20 } }
+    end
+
+    let(:mail) { DailyActivityMailer.send_summary(admin_email, '06/01/21', **activities_summary) }
+
+    it 'sets the headers' do
+      expect(mail.subject).to eq('BA activies summary for 06/01/21')
+      expect(mail.to).to eq([admin_email])
+    end
+
+    it 'includes summary about certificates sources actions' do
+      expect(mail.body.encoded).to match(/15 new certificates files/)
+      expect(mail.body.encoded).to match(/7 were succesfully processed/)
+      expect(mail.body.encoded).to match(/5 were partially processed/)
+      expect(mail.body.encoded).to match(/3 failed/)
+    end
+
+    it 'includes summary about certificates actions' do
+      expect(mail.body.encoded).to match(/5439 certificates/)
+      expect(mail.body.encoded).to match(/5209 were succesfully generated and sent/)
+      expect(mail.body.encoded).to match(/20 certificates failed/)
+    end
+  end
+end

--- a/spec/mailers/previews/daily_activity_mailer_preview.rb
+++ b/spec/mailers/previews/daily_activity_mailer_preview.rb
@@ -1,0 +1,10 @@
+require 'factory_bot'
+# Preview all emails at http://localhost:3000/rails/mailers/daily_activity_mailer
+class DailyActivityMailerPreview < ActionMailer::Preview
+  def send_summary
+    activities_summary = { certificates_sources: { new: 15, succesfully_processed: 7, partially_processed: 5, failed: 3 },
+                           certificates:         { entries: 5439, generated_and_sent: 5209, failed: 20 } }
+    admin_email = FactoryBot.build(:admin).email
+    DailyActivityMailer.send_summary(admin_email, '06/01/21', **activities_summary)
+  end
+end

--- a/spec/services/activities/daily_summary_data_provider_spec.rb
+++ b/spec/services/activities/daily_summary_data_provider_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ::Activities::DailySummaryDataProvider do
+  describe '.call' do
+    it 'queries for CertificatesSource created in the last 24 hrs' do
+      skip '[TO DO] Not yet implemented...'
+    end
+
+    it 'counts CertificatesSource with the flag :processed' do
+      skip '[TO DO] Not yet implemented...'
+    end
+
+    it 'counts CertificatesSource with the flag :failed' do
+      skip '[TO DO] Not yet implemented...'
+    end
+
+    it 'sums all Certificates from the CertificatesSources' do
+      skip '[TO DO] Not yet implemented...'
+    end
+
+    it 'sums certificates_generated_and_sent from CertificatesSources' do
+      skip '[TO DO] Not yet implemented...'
+    end
+
+    it 'sums certificates_failed from CertificatesSources' do
+      skip '[TO DO] Not yet implemented...'
+    end
+  end
+end


### PR DESCRIPTION
Breaking changes:
- `admins` table added

Changes:
- daily summary mailer defined
- job for calling the summary mailer for all of the admins added
- example cron for triggering the job specified
- specs for the functionalities added

Resolves #4